### PR TITLE
Fix CheerpJ filesystem path for Minecraft storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To add mods to your Minecraft installation:
 This project uses [CheerpJ](https://cheerpj.com), a Java-to-JavaScript compiler that allows Java applications to run in the browser. The implementation:
 
 1. **Loads Local JAR**: Fetches the Minecraft 1.2.5 client JAR from the local `minecraft/bin/` folder
-2. **Virtual Filesystem**: Writes the JAR into CheerpJ's virtual filesystem at `/files/.minecraft/bin/minecraft-1.2.5.jar`
+2. **Virtual Filesystem**: Writes the JAR into CheerpJ's virtual filesystem at `/app/.minecraft/bin/minecraft-1.2.5.jar`
 3. **Initializes CheerpJ**: Sets up the Java runtime environment in the browser
 4. **Runs Minecraft**: Executes the unmodified Minecraft client JAR with LWJGL libraries
 5. **Loads Mods**: Automatically loads any mods placed in the `/minecraft/mods` folder
@@ -105,8 +105,8 @@ This project uses [CheerpJ](https://cheerpj.com), a Java-to-JavaScript compiler 
 The application uses CheerpJ's virtual filesystem to store and run the JAR file. The LWJGL libraries are stored alongside the client in the CheerpJ filesystem. The process is:
 
 1. The JAR file is loaded from `/minecraft/bin/minecraft-1.2.5.jar` on the web server
-2. It's written to `/files/.minecraft/bin/minecraft-1.2.5.jar` in CheerpJ's virtual filesystem
-3. CheerpJ runs Minecraft with the classpath: `/files/.minecraft/bin/minecraft-1.2.5.jar:/files/lwjgl-2.9.3.jar:/files/lwjgl_util-2.9.3.jar`
+2. It's written to `/app/.minecraft/bin/minecraft-1.2.5.jar` in CheerpJ's virtual filesystem
+3. CheerpJ runs Minecraft with the classpath: `/app/.minecraft/bin/minecraft-1.2.5.jar:/app/lwjgl-2.9.3.jar:/app/lwjgl_util-2.9.3.jar`
 
 ## File Structure
 

--- a/index.html
+++ b/index.html
@@ -196,12 +196,12 @@
 
     <script>
         // Minecraft JAR configuration - mirror typical .minecraft layout and use core minecraft folder
-        const MINECRAFT_DIR = "/files/.minecraft";
+        const MINECRAFT_DIR = "/app/.minecraft";
         const LOCAL_MINECRAFT_DIR = "/minecraft";
         const LOCAL_JAR_PATH = `${LOCAL_MINECRAFT_DIR}/bin/minecraft-1.2.5.jar`;
         const CHEERPJ_JAR_PATH = `${MINECRAFT_DIR}/bin/minecraft-1.2.5.jar`;
-        const LWJGL_JAR_PATH = "/files/lwjgl-2.9.3.jar";
-        const LWJGL_UTIL_JAR_PATH = "/files/lwjgl_util-2.9.3.jar";
+        const LWJGL_JAR_PATH = "/app/lwjgl-2.9.3.jar";
+        const LWJGL_UTIL_JAR_PATH = "/app/lwjgl_util-2.9.3.jar";
         const JAR_LIBS = `${CHEERPJ_JAR_PATH}:${LWJGL_JAR_PATH}:${LWJGL_UTIL_JAR_PATH}`;
 
         // URL parameters for testing/automation
@@ -222,7 +222,7 @@
                 await cheerpjInit({
                     version: 8,
                     enableX11: true,
-                    javaProperties: ["java.library.path=/app/cheerpj-natives/natives","user.home=/files"],
+                    javaProperties: ["java.library.path=/app/cheerpj-natives/natives","user.home=/app"],
                     preloadResources: {
                         "/lt/8/jre/lib/rt.jar": [0,131072,1310720,1572864,4456448,4849664,5111808,5505024,7995392,8126464,9699328,9830400,9961472,11534336,11665408,12189696,12320768,12582912,13238272,13369344,15073280,15335424,15466496,15597568,15990784,16121856,16252928,16384000,16777216,16908288,17039360,17563648,17694720,17825792,17956864,18087936,18219008,18612224,18743296,18874368,19005440,19136512,19398656,19791872,20054016,20709376,20840448,21757952,21889024,26869760],
                         "/lt/etc/users": [0,131072],


### PR DESCRIPTION
## Summary
- store Minecraft and LWJGL jars in /app instead of unavailable /files
- document new /app paths in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f2ac2b45883339dc61709a9b647ef