### PR TITLE
Stream JARs to CheerpJ in write loop

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,24 +349,41 @@
                             return;
                         }
                         
-                        console.log('Calling cheerpOSWrite...');
-                        cheerpOSWrite(fds, fd, bytes, 0, bytes.length, w => {
-                            console.log('cheerpOSWrite callback called with bytes written:', w);
-                            
-                            if (w < 0) {
+                        console.log('Starting chunked cheerpOSWrite...');
+                        const CHUNK_SIZE = 64 * 1024; // 64KB
+                        let offset = 0;
+                        let totalWritten = 0;
+
+                        function writeChunk() {
+                            if (offset >= bytes.length) {
+                                console.log('Calling cheerpOSClose...');
+                                cheerpOSClose(fds, fd);
                                 clearTimeout(timeout);
-                                reject(new Error('Failed to write to CheerpJ filesystem, written: ' + w));
+                                console.log(`${jarName} written to CheerpJ filesystem successfully`);
+                                resolve();
                                 return;
                             }
-                            
-                            console.log('Calling cheerpOSClose...');
-                            cheerpOSClose(fds, fd);
-                            
-                            // Don't wait for close callback, just resolve immediately
-                            clearTimeout(timeout);
-                            console.log(`${jarName} written to CheerpJ filesystem successfully`);
-                            resolve();
-                        });
+
+                            const end = Math.min(offset + CHUNK_SIZE, bytes.length);
+                            const chunk = bytes.subarray(offset, end);
+
+                            cheerpOSWrite(fds, fd, chunk, 0, chunk.length, w => {
+                                console.log('cheerpOSWrite callback called with bytes written:', w);
+
+                                if (w < 0) {
+                                    clearTimeout(timeout);
+                                    reject(new Error('Failed to write to CheerpJ filesystem, written: ' + w));
+                                    return;
+                                }
+
+                                offset += w;
+                                totalWritten += w;
+                                console.log(`Total bytes written: ${totalWritten}/${bytes.length}`);
+                                writeChunk();
+                            });
+                        }
+
+                        writeChunk();
                     });
                 });
 


### PR DESCRIPTION
## Summary
- Write JAR files to the CheerpJ filesystem in 64KB chunks
- Track cumulative bytes written before closing file descriptor

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68900a09ecc883338ab063cc919606e9