### PR TITLE
Disable class verification for modded JARs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ minecraft-1.2.5/
 - Check browser console for error messages
 - Ensure JavaScript is enabled in your browser
 
+**SHA1 digest error / signature mismatch**
+- Occurs when the JAR's `META-INF` signatures don't match its contents
+- Removing the `META-INF` folder or running with the `-noverify` JVM flag resolves this
+- The web launcher includes `-noverify` by default
+
 **404 Errors for LWJGL**
 - This is normal - LWJGL libraries are provided internally by CheerpJ
 - The game should still work despite these errors in the network tab

--- a/index.html
+++ b/index.html
@@ -486,7 +486,7 @@
                 window.lwjglCanvasElement = document.getElementById('minecraft-canvas');
                 console.log('LWJGL canvas element set:', window.lwjglCanvasElement);
                 const launchArgs = buildLaunchArgs();
-                cheerpjRunMain("net.minecraft.client.Minecraft", JAR_LIBS, ...launchArgs);
+                cheerpjRunMain("net.minecraft.client.Minecraft", JAR_LIBS, "-noverify", ...launchArgs);
 
             } catch (error) {
                 console.error('Failed to start game:', error);


### PR DESCRIPTION
## Summary
- launch Minecraft with `-noverify` to avoid signature errors from modded JARs
- document SHA1 digest fix in troubleshooting guide

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689013f93cdc833397d6fe04b8333355