### PR TITLE
stub missing unsafe throw exception

### DIFF
--- a/index.html
+++ b/index.html
@@ -473,6 +473,11 @@
         try {
           await cheerpjInit();
 
+          // Stub missing native method for CheerpJ runtime
+          window.Java_sun_misc_Unsafe_throwException = function (unsafePtr, throwable) {
+            throw throwable;
+          };
+
           // Cache frequently used DOM elements once the runtime is ready
           loading = document.getElementById('loading');
           intro = document.getElementById('intro');


### PR DESCRIPTION
## Summary
- stub missing native method sun.misc.Unsafe.throwException for CheerpJ

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689086c348348333a0618e2b30375e47